### PR TITLE
Implement group chat support with mention detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,18 @@ binding = "RATE_LIMITS"
 id = "ghi789jkl012"  # Use the actual ID from create command
 ```
 
-### 4. Set Environment Secrets
+### 4. Configure Bot Username
+
+Set the bot username in `wrangler.toml` (this is used for group chat mention detection):
+
+```toml
+[vars]
+BOT_USERNAME = "YourBotUsernameHere"
+```
+
+Replace `YourBotUsernameHere` with your actual bot username (without the @).
+
+### 5. Set Environment Secrets
 
 ```bash
 # Set required secrets
@@ -95,13 +106,13 @@ source .env && echo $BOT_TOKEN | npx wrangler secret put BOT_TOKEN
 source .env && echo $WEBHOOK_SECRET | npx wrangler secret put WEBHOOK_SECRET
 ```
 
-### 5. Deploy Worker
+### 6. Deploy Worker
 
 ```bash
 npm run deploy
 ```
 
-### 6. Configure Telegram Webhook
+### 7. Configure Telegram Webhook
 
 First, update your `.env` file with the actual worker URL from the deployment output. Then set the Telegram webhook:
 
@@ -124,7 +135,7 @@ Verify the webhook was set correctly:
 source .env && curl "https://api.telegram.org/bot${BOT_TOKEN}/getWebhookInfo"
 ```
 
-### 7. Test Your Bot
+### 8. Test Your Bot
 
 Send a message to your bot on Telegram. It should respond with:
 ```
@@ -212,10 +223,18 @@ zenfast/
 ### Message Processing
 
 - **Private chats**: Processes all text messages
-- **Group chats**: Processes only:
-  - Messages mentioning `@your_bot_username`
-  - Commands starting with `/`
-  - Replies to bot messages
+- **Group chats**: Processes only messages that:
+  - Contain bot commands (detected via Telegram entities)
+  - Mention the bot `@BOT_USERNAME` (detected via Telegram entities or text fallback)
+  - Are replies to messages sent by the bot (detected via bot ID from token)
+
+**Group Chat Examples:**
+- ✅ `/start` - Bot command
+- ✅ `@ZenFastBot hello` - Bot mention with entity
+- ✅ `hello @ZenFastBot` - Bot mention in text
+- ✅ Replying to a bot message - Reply detection
+- ❌ `Regular group message` - Ignored
+- ❌ `@OtherBot hello` - Different bot mention
 
 ### Echo Functionality
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export default {
       return new Response('Bad Request', { status: 400 });
     }
 
-    if (!shouldProcessMessage(update)) {
+    if (!shouldProcessMessage(update, env)) {
       return new Response('OK', { status: 200 });
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface MessageEntity {
 // Worker Environment
 export interface Env {
   BOT_TOKEN: string;
+  BOT_USERNAME: string;
   WEBHOOK_SECRET: string;
   API_KEYS: KVNamespace;
   CHATS: KVNamespace;

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -17,6 +17,7 @@ describe('Auth Module', () => {
     
     env = {
       BOT_TOKEN: 'test-token',
+      BOT_USERNAME: 'TestBot',
       WEBHOOK_SECRET: 'test-secret',
       API_KEYS: mockApiKeys as any,
       CHATS: mockChats as any,

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -17,6 +17,7 @@ describe('Commands Module', () => {
     
     env = {
       BOT_TOKEN: 'test-token',
+      BOT_USERNAME: 'TestBot',
       WEBHOOK_SECRET: 'test-secret',
       API_KEYS: mockApiKeys as any,
       CHATS: mockChats as any,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,6 +11,7 @@ vi.spyOn(console, 'error').mockImplementation(() => {});
 
 const mockEnv: Env = {
   BOT_TOKEN: 'test-bot-token',
+  BOT_USERNAME: 'TestBot',
   WEBHOOK_SECRET: 'test-secret',
   API_KEYS: {} as KVNamespace,
   CHATS: {} as KVNamespace,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -20,6 +20,7 @@ describe('Authentication Integration Tests', () => {
     
     mockEnv = {
       BOT_TOKEN: 'test-bot-token',
+      BOT_USERNAME: 'TestBot',
       WEBHOOK_SECRET: 'test-secret',
       API_KEYS: mockApiKeys as any,
       CHATS: mockChats as any,

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -4,7 +4,8 @@ import { Env, Update } from '../src/types.ts';
 
 // Mock environment
 const mockEnv: Env = {
-  BOT_TOKEN: 'test-bot-token',
+  BOT_TOKEN: '123456789:ABCdefGHIjklMNOpqrsTUVwxyz',
+  BOT_USERNAME: 'ZenFastBot',
   WEBHOOK_SECRET: 'test-secret-token',
   API_KEYS: {} as KVNamespace,
   CHATS: {} as KVNamespace,
@@ -78,73 +79,280 @@ describe('Update Parsing', () => {
 });
 
 describe('Message Processing Logic', () => {
-  it('should process private chat messages', () => {
-    const update: Update = {
-      update_id: 1,
-      message: {
-        message_id: 1,
-        chat: { id: 123, type: 'private' },
-        date: 1234567890,
-        text: 'Hello, bot!',
-      },
-    };
+  describe('Private chats', () => {
+    it('should process private chat messages', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 123, type: 'private' },
+          date: 1234567890,
+          text: 'Hello, bot!',
+        },
+      };
 
-    expect(shouldProcessMessage(update)).toBe(true);
+      expect(shouldProcessMessage(update, mockEnv)).toBe(true);
+    });
   });
 
-  it('should process bot commands in groups', () => {
-    const update: Update = {
-      update_id: 1,
-      message: {
-        message_id: 1,
-        chat: { id: -123, type: 'group' },
-        date: 1234567890,
-        text: '/start',
-      },
-    };
+  describe('Group chats - entity-based detection', () => {
+    it('should process bot commands via entities', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: '/start',
+          entities: [
+            { type: 'bot_command', offset: 0, length: 6 }
+          ],
+        },
+      };
 
-    expect(shouldProcessMessage(update)).toBe(true);
+      expect(shouldProcessMessage(update, mockEnv)).toBe(true);
+    });
+
+    it('should process bot mentions via entities', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: 'Hello @ZenFastBot!',
+          entities: [
+            { type: 'mention', offset: 6, length: 11 }
+          ],
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(true);
+    });
+
+    it('should ignore mentions of other bots via entities', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: 'Hello @OtherBot!',
+          entities: [
+            { type: 'mention', offset: 6, length: 9 }
+          ],
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(false);
+    });
   });
 
-  it('should process bot mentions in groups', () => {
-    const update: Update = {
-      update_id: 1,
-      message: {
-        message_id: 1,
-        chat: { id: -123, type: 'group' },
-        date: 1234567890,
-        text: 'Hello @zenfast_bot!',
-      },
-    };
+  describe('Group chats - reply detection', () => {
+    it('should process replies to bot messages', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 2,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: 'This is a reply',
+          reply_to_message: {
+            message_id: 1,
+            chat: { id: -123, type: 'group' },
+            date: 1234567880,
+            text: 'Bot response',
+            from: {
+              id: 123456789,
+              is_bot: true,
+              first_name: 'ZenFast Bot'
+            }
+          }
+        },
+      };
 
-    expect(shouldProcessMessage(update)).toBe(true);
+      expect(shouldProcessMessage(update, mockEnv)).toBe(true);
+    });
+
+    it('should ignore replies to other bots', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 2,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: 'This is a reply',
+          reply_to_message: {
+            message_id: 1,
+            chat: { id: -123, type: 'group' },
+            date: 1234567880,
+            text: 'Other bot response',
+            from: {
+              id: 987654321,
+              is_bot: true,
+              first_name: 'Other Bot'
+            }
+          }
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(false);
+    });
+
+    it('should ignore replies to users', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 2,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: 'This is a reply',
+          reply_to_message: {
+            message_id: 1,
+            chat: { id: -123, type: 'group' },
+            date: 1234567880,
+            text: 'User message',
+            from: {
+              id: 555666777,
+              is_bot: false,
+              first_name: 'John'
+            }
+          }
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(false);
+    });
   });
 
-  it('should ignore regular group messages', () => {
-    const update: Update = {
-      update_id: 1,
-      message: {
-        message_id: 1,
-        chat: { id: -123, type: 'group' },
-        date: 1234567890,
-        text: 'Regular group message',
-      },
-    };
+  describe('Group chats - text fallback', () => {
+    it('should process bot mentions via text fallback', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: 'Hello @ZenFastBot how are you?',
+        },
+      };
 
-    expect(shouldProcessMessage(update)).toBe(false);
+      expect(shouldProcessMessage(update, mockEnv)).toBe(true);
+    });
+
+    it('should ignore regular group messages', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: 'Regular group message',
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(false);
+    });
+
+    it('should ignore mentions of other bots via text', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: 'Hello @SomeOtherBot!',
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(false);
+    });
   });
 
-  it('should ignore messages without text', () => {
-    const update: Update = {
-      update_id: 1,
-      message: {
-        message_id: 1,
-        chat: { id: 123, type: 'private' },
-        date: 1234567890,
-      },
-    };
+  describe('Supergroups', () => {
+    it('should process bot commands in supergroups', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -1001234567890, type: 'supergroup' },
+          date: 1234567890,
+          text: '/help',
+          entities: [
+            { type: 'bot_command', offset: 0, length: 5 }
+          ],
+        },
+      };
 
-    expect(shouldProcessMessage(update)).toBe(false);
+      expect(shouldProcessMessage(update, mockEnv)).toBe(true);
+    });
+
+    it('should process bot mentions in supergroups', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -1001234567890, type: 'supergroup' },
+          date: 1234567890,
+          text: '@ZenFastBot help me',
+          entities: [
+            { type: 'mention', offset: 0, length: 11 }
+          ],
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(true);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should ignore messages without text', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: 123, type: 'private' },
+          date: 1234567890,
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(false);
+    });
+
+    it('should handle multiple mentions correctly', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: '@OtherBot @ZenFastBot hello',
+          entities: [
+            { type: 'mention', offset: 0, length: 9 },
+            { type: 'mention', offset: 10, length: 11 }
+          ],
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(true);
+    });
+
+    it('should handle command@bot format via entities', () => {
+      const update: Update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          chat: { id: -123, type: 'group' },
+          date: 1234567890,
+          text: '/start@ZenFastBot',
+          entities: [
+            { type: 'bot_command', offset: 0, length: 16 }
+          ],
+        },
+      };
+
+      expect(shouldProcessMessage(update, mockEnv)).toBe(true);
+    });
   });
 });
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,9 @@ compatibility_date = "2024-01-01"
 # BOT_TOKEN - Telegram bot token from @BotFather
 # WEBHOOK_SECRET - Secret token for webhook validation
 
+[vars]
+BOT_USERNAME = "ZenFastBot"
+
 [[kv_namespaces]]
 binding = "API_KEYS"
 id = "97a2817b085844a7bcd45e2c55d67da6"


### PR DESCRIPTION
Add sophisticated message filtering for group chats using entity-based detection, reply recognition, and text fallback mechanisms.

Key changes:
- Add BOT_USERNAME configuration to Env interface and wrangler.toml
- Enhance shouldProcessMessage() with entity-based bot command and mention detection
- Implement reply-to-bot detection using bot ID extracted from BOT_TOKEN
- Add text-based fallback for mentions when entities unavailable
- Update all test mock environments to include BOT_USERNAME
- Add 16 comprehensive test cases covering all filtering scenarios
- Update documentation with group chat setup and behavior examples

Groups now process only:
- Bot commands (detected via Telegram entities)
- Bot mentions @BOT_USERNAME (entity-based + text fallback)
- Replies to bot messages (bot ID comparison)
- Ignores regular group messages and other bot mentions

Closes #6 