### PR TITLE
ci: adopt hybrid workflows (configure-prod, conditional webhook); add ci-update-webhook script; docs: CI/CD section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Unit tests (with coverage)
+        run: npx vitest --run --coverage --reporter=dot
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/configure-prod.yml
+++ b/.github/workflows/configure-prod.yml
@@ -1,0 +1,67 @@
+name: Configure (prod)
+
+on:
+  workflow_dispatch:
+    inputs:
+      update_webhook:
+        description: "Force update Telegram webhook after configuring secrets"
+        required: false
+        type: boolean
+        default: false
+      worker_route:
+        description: "Worker base URL (e.g., https://zenfast.<subdomain>.workers.dev). If empty, falls back to WORKER_ROUTE secret."
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: configure-prod
+  cancel-in-progress: false
+
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Cloudflare secrets
+        if: ${{ secrets.BOT_TOKEN != '' && secrets.WEBHOOK_SECRET != '' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          printf "%s" "${{ secrets.BOT_TOKEN }}" | npx wrangler secret put BOT_TOKEN
+          printf "%s" "${{ secrets.WEBHOOK_SECRET }}" | npx wrangler secret put WEBHOOK_SECRET
+
+      - name: Determine Worker URL
+        id: route
+        run: |
+          if [ -n "${{ inputs.worker_route }}" ]; then
+            echo "route=${{ inputs.worker_route }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ secrets.WORKER_ROUTE }}" ]; then
+            echo "route=${{ secrets.WORKER_ROUTE }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "No worker route provided; skipping webhook update."
+          fi
+
+      - name: Force update Telegram webhook
+        if: ${{ inputs.update_webhook && steps.route.outputs.route != '' && secrets.BOT_TOKEN != '' && secrets.WEBHOOK_SECRET != '' }}
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          WORKER_ROUTE: ${{ steps.route.outputs.route }}
+        run: npx tsx scripts/ci-update-webhook.ts --force

--- a/.github/workflows/configure-prod.yml
+++ b/.github/workflows/configure-prod.yml
@@ -44,6 +44,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
+          # Security note: Secrets are passed via stdin (not command args) and GitHub Actions
+          # automatically masks secret values in logs. The ephemeral runner is destroyed after job.
           printf "%s" "${{ secrets.BOT_TOKEN }}" | npx wrangler secret put BOT_TOKEN
           printf "%s" "${{ secrets.WEBHOOK_SECRET }}" | npx wrangler secret put WEBHOOK_SECRET
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,74 @@
+name: Deploy (prod)
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+
+      - name: Deploy Worker
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -eo pipefail
+          OUT=$(npx wrangler deploy 2>&1 | tee /dev/stderr)
+          URL=$(echo "$OUT" | grep -oE 'https://[a-zA-Z0-9.-]+\.workers\.dev' | head -1 || true)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Determine Worker URL
+        id: route
+        run: |
+          if [ -n "${{ secrets.WORKER_ROUTE }}" ]; then
+            echo "route=${{ secrets.WORKER_ROUTE }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ steps.deploy.outputs.url }}" ]; then
+            echo "route=${{ steps.deploy.outputs.url }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "No worker route available; skipping webhook setup and health check."
+          fi
+
+      - name: Conditionally update Telegram webhook
+        if: ${{ steps.route.outputs.route != '' && secrets.BOT_TOKEN != '' && secrets.WEBHOOK_SECRET != '' }}
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          WORKER_ROUTE: ${{ steps.route.outputs.route }}
+        run: npx tsx scripts/ci-update-webhook.ts
+
+      - name: Smoke test health
+        if: ${{ steps.route.outputs.route != '' }}
+        run: |
+          set -e
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${{ steps.route.outputs.route }}/health")
+          echo "Health status: $STATUS"
+          if [ "$STATUS" -ne 200 ]; then
+            echo "Health endpoint returned $STATUS"
+            exit 1
+          fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,6 +41,10 @@ jobs:
           set -eo pipefail
           OUT=$(npx wrangler deploy 2>&1 | tee /dev/stderr)
           URL=$(echo "$OUT" | grep -oE 'https://[a-zA-Z0-9.-]+\.workers\.dev' | head -1 || true)
+          if [ -z "$URL" ]; then
+            echo "Warning: Could not extract worker URL from wrangler output" >&2
+            echo "This is expected if using custom domains. Falling back to WORKER_ROUTE secret." >&2
+          fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Determine Worker URL

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -447,3 +447,31 @@ npm run build     # Compilation check
 - **Wrangler CLI**: https://developers.cloudflare.com/workers/wrangler/
 
 For issues specific to ZenFast, check the repository's issue tracker.
+
+
+## CI/CD (Hybrid) Workflows
+
+The repository uses a hybrid approach to manage production deployments and sensitive configuration:
+
+- Deploy (prod) workflow:
+  - Triggers: on push to main and manual dispatch.
+  - Action: builds and deploys the Cloudflare Worker.
+  - Secrets: does NOT write Cloudflare Worker secrets during deploy.
+  - Webhook: conditionally updates the Telegram webhook using a safe script (only when the route differs), keeping logs free of secrets.
+  - Health: runs a simple /health check against the deployed route.
+
+- Configure (prod) workflow:
+  - Trigger: manual (workflow_dispatch), approval-gated via the prod environment.
+  - Action: writes/updates Cloudflare Worker secrets BOT_TOKEN and WEBHOOK_SECRET via wrangler.
+  - Optional: can force-update the Telegram webhook after secrets are applied.
+
+Required GitHub environment secrets (prod):
+- CLOUDFLARE_API_TOKEN (with Workers Script and KV edit permissions)
+- CLOUDFLARE_ACCOUNT_ID
+- BOT_TOKEN
+- WEBHOOK_SECRET
+- WORKER_ROUTE (optional; if not set, the deploy workflow will use the workers.dev URL returned by wrangler)
+
+Rotation and recovery:
+- To rotate secrets or recover from drift (e.g., a deleted secret), run the Configure (prod) workflow.
+- After changing your route, either set WORKER_ROUTE or let the deploy discover the new workers.dev URL; the webhook will update automatically only if it differs.

--- a/scripts/ci-update-webhook.ts
+++ b/scripts/ci-update-webhook.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+
+// CI-friendly script to conditionally update the Telegram webhook
+// - Reads env vars: BOT_TOKEN, WEBHOOK_SECRET, WORKER_ROUTE
+// - If --force is provided, always sets the webhook
+// - Otherwise, calls getWebhookInfo and updates only when the URL differs
+// - Does not log secrets
+
+function env(name: string): string | undefined {
+  const v = process.env[name];
+  if (typeof v === 'string') {
+    // Trim but preserve actual empty strings as empty
+    return v.trim();
+  }
+  return undefined;
+}
+
+const BOT_TOKEN = env('BOT_TOKEN');
+const WEBHOOK_SECRET = env('WEBHOOK_SECRET');
+const WORKER_ROUTE = env('WORKER_ROUTE');
+const FORCE = process.argv.includes('--force');
+
+function fail(msg: string, code = 1): never {
+  console.error(msg);
+  process.exit(code);
+}
+
+async function tg<T = any>(method: string, init?: RequestInit): Promise<T> {
+  const url = `https://api.telegram.org/bot${BOT_TOKEN}/${method}`;
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    const text = await res.text();
+    fail(`Telegram API ${method} failed with HTTP ${res.status}: ${text}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+async function main() {
+  console.log('🔧 CI: Conditional Telegram webhook update');
+
+  if (!BOT_TOKEN) return fail('BOT_TOKEN is required via environment variable');
+  if (!WEBHOOK_SECRET) return fail('WEBHOOK_SECRET is required via environment variable');
+  if (!WORKER_ROUTE) return fail('WORKER_ROUTE is required via environment variable');
+
+  if (!/^https:\/\//.test(WORKER_ROUTE) || WORKER_ROUTE.includes('*')) {
+    return fail('Invalid WORKER_ROUTE format');
+  }
+
+  const desiredUrl = `${WORKER_ROUTE.replace(/\/$/, '')}/webhook`;
+
+  if (!FORCE) {
+    // Check current webhook status without leaking secrets
+    type WebhookInfo = { ok: boolean; result?: { url?: string } ; description?: string };
+    const info = await tg<WebhookInfo>('getWebhookInfo');
+    if (!info.ok) {
+      return fail(`getWebhookInfo returned not ok: ${info.description ?? 'unknown error'}`);
+    }
+
+    const currentUrl = info.result?.url ?? '';
+    if (currentUrl === desiredUrl) {
+      console.log(`✅ Webhook already configured (${desiredUrl}); skipping setWebhook`);
+      return;
+    }
+    if (!currentUrl) {
+      console.log('ℹ️  No webhook configured currently; will set it now');
+    } else {
+      console.log(`ℹ️  Webhook mismatch: current=${currentUrl}, desired=${desiredUrl}; updating`);
+    }
+  } else {
+    console.log('⚠️  Force mode enabled; will setWebhook regardless of current state');
+  }
+
+  // Set webhook
+  type TgResponse = { ok: boolean; description?: string };
+  const setBody = JSON.stringify({ url: desiredUrl, secret_token: WEBHOOK_SECRET });
+  const result = await tg<TgResponse>('setWebhook', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: setBody,
+  });
+  if (!result.ok) {
+    return fail(`setWebhook returned not ok: ${result.description ?? 'unknown error'}`);
+  }
+  console.log('✅ setWebhook succeeded');
+}
+
+main().catch((err) => {
+  console.error('❌ Error in ci-update-webhook.ts:', err?.message ?? err);
+  process.exit(1);
+});

--- a/scripts/ci-update-webhook.ts
+++ b/scripts/ci-update-webhook.ts
@@ -25,7 +25,7 @@ function fail(msg: string, code = 1): never {
   process.exit(code);
 }
 
-async function tg<T = any>(method: string, init?: RequestInit): Promise<T> {
+async function tg<T = unknown>(method: string, init?: RequestInit): Promise<T> {
   const url = `https://api.telegram.org/bot${BOT_TOKEN}/${method}`;
   const res = await fetch(url, init);
   if (!res.ok) {


### PR DESCRIPTION
Closes #16 

This was created by Jetbrains Junie for a change. It worked well (I think now with gpt-5!), but it is so slow. Also it gets stuck on using `gh`. `gh` has a pager, and it just waits forever on the command to finish.

Update: added the below to idea terminal config with a hope to fix the stuck `gh`
```
export PAGER=cat
export LESS=
```

---

## Summary
Adopt a hybrid CI/CD approach for ZenFast production deployments:
- Deploy (prod) workflow: builds and deploys the Cloudflare Worker; conditionally updates the Telegram webhook only when needed; runs a simple health check.
- Configure (prod) workflow: manual, approval‑gated job to set/update Cloudflare Worker secrets (BOT_TOKEN, WEBHOOK_SECRET) and optionally force‑update the webhook.
- Add a CI‑friendly webhook helper script (scripts/ci-update-webhook.ts) and document the setup in docs/deployment.md.

## Motivation
Balance safety and operability for production:
- Reduce secret write surface during routine deploys (principle of least privilege).
- Keep deployments reliable: webhook auto‑updates when the route changes, but without gratuitous secret writes.
- Make rotations and drift recovery explicit and auditable via a dedicated, approval‑gated Configure workflow.

## What’s changed
- .github/workflows/deploy-prod.yml
  - Removes automatic writes of Cloudflare secrets during deploy.
  - Deploys with Wrangler and extracts the workers.dev URL when available.
  - Determines the Worker route from WORKER_ROUTE secret or deploy output.
  - Conditionally updates the Telegram webhook using scripts/ci-update-webhook.ts (only if current webhook URL differs, or can be forced).
  - Adds a /health smoke check.
  - Uses environment: prod and a concurrency group (deploy-prod).

- .github/workflows/configure-prod.yml (new)
  - Manual (workflow_dispatch) job, environment: prod (approval‑gated as desired).
  - Writes/updates Cloudflare secrets BOT_TOKEN and WEBHOOK_SECRET via Wrangler.
  - Optional inputs: update_webhook (boolean), worker_route (string override or fallback to WORKER_ROUTE secret).
  - Uses concurrency group configure-prod.

- scripts/ci-update-webhook.ts (new)
  - CI‑safe helper: reads BOT_TOKEN, WEBHOOK_SECRET, WORKER_ROUTE from env.
  - If not forced, calls getWebhookInfo and updates only when URL differs (idempotent).
  - Avoids logging secrets; validates route format; provides clear error messages.

- docs/deployment.md
  - Adds a "CI/CD (Hybrid) Workflows" section describing the split responsibility model, required secrets, and rotation/recovery process.

## Required GitHub environment and secrets (prod)
- CLOUDFLARE_API_TOKEN (Workers Scripts:Edit, Workers KV:Edit)
- CLOUDFLARE_ACCOUNT_ID
- BOT_TOKEN
- WEBHOOK_SECRET
- WORKER_ROUTE (optional; if unset, deploy uses workers.dev URL from wrangler output)

Make sure the GitHub Environment "prod" exists and holds these secrets. You may also require environment approvals for Configure/Deploy as appropriate.

## Security and compliance notes
- Routine deploys do not write secrets, reducing risk of accidental overrides and limiting exposure.
- Webhook updates are conditional and avoid printing sensitive values in logs.
- Secret rotations (or recovery from drift) are explicit via the Configure (prod) workflow, which can be approval‑gated.

## How to verify
- Push to main or run Deploy (prod) via workflow_dispatch:
  - Confirm successful wrangler deploy.
  - If WORKER_ROUTE is unset, confirm the job discovers the workers.dev URL.
  - If a route is determined and secrets exist, the webhook step should:
    - Skip if already matching (message: "Webhook already configured …; skipping").
    - Or update when mismatched (message indicates mismatch and success).
  - Health check returns 200 from /health.

- Run Configure (prod):
  - Confirm BOT_TOKEN and WEBHOOK_SECRET are written via Wrangler.
  - Optionally pass update_webhook=true and a worker_route input to force setWebhook.

## Rollout / Backward compatibility
- No breaking app changes.
- If the prod environment or secrets are missing, the workflows will no‑op on webhook/secrets steps with clear messages.
- Existing deployments continue to work; the new model simply avoids rewriting secrets during deploys.

## Risks / mitigations
- If secrets are missing in Cloudflare, deploys won’t fix them automatically (by design). Mitigation: run Configure (prod).
- If WORKER_ROUTE is incorrect, webhook step fails fast; provide the correct route via the secret or Configure input.

## Links
- Workflows: .github/workflows/deploy-prod.yml, .github/workflows/configure-prod.yml
- Helper script: scripts/ci-update-webhook.ts
- Docs: docs/deployment.md (CI/CD Hybrid section)

## Checklist
- [x] CI builds TypeScript and runs tests
- [x] Deploy (prod) workflow deploys and health‑checks
- [x] Configure (prod) workflow can set secrets and (optionally) update webhook
- [x] Documentation updated