### PR TITLE
Add weekly and monthly statistics commands

### DIFF
--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -6,6 +6,8 @@ import {
   handleEndCommand,
   handleStatsCommand,
   handleTimezoneCommand,
+  handleWeekCommand,
+  handleMonthCommand,
   extractCommand, 
   routeCommand 
 } from '../src/commands';
@@ -552,6 +554,132 @@ describe('Commands Module', () => {
       const result = await routeCommand('help', chatId, testUser, messageId, '/help', env);
       
       expect(result).toBeNull();
+    });
+
+    it('should route week command correctly', async () => {
+      const chatId = 12345;
+      const messageId = 100;
+      
+      // Set up authentication
+      const keyHash = 'sha256:testhash';
+      const apiKeyData: ApiKeyData = {
+        name: 'Test Key',
+        expiry: new Date(Date.now() + 86400000).toISOString(),
+        created: new Date().toISOString()
+      };
+      await mockApiKeys.put(keyHash, JSON.stringify(apiKeyData));
+      
+      const chatAuth: ChatAuthData = {
+        api_key_hash: keyHash,
+        authenticated_at: new Date().toISOString(),
+        authenticated_by: testUser
+      };
+      await mockChats.put(chatId.toString(), JSON.stringify(chatAuth));
+      
+      const result = await routeCommand('week', chatId, testUser, messageId, '/week', env);
+      
+      expect(result).toBeTruthy();
+      expect(result!.text).toContain("📅 This Week's Fasting Summary");
+    });
+
+    it('should route month command correctly', async () => {
+      const chatId = 12345;
+      const messageId = 100;
+      
+      // Set up authentication
+      const keyHash = 'sha256:testhash';
+      const apiKeyData: ApiKeyData = {
+        name: 'Test Key',
+        expiry: new Date(Date.now() + 86400000).toISOString(),
+        created: new Date().toISOString()
+      };
+      await mockApiKeys.put(keyHash, JSON.stringify(apiKeyData));
+      
+      const chatAuth: ChatAuthData = {
+        api_key_hash: keyHash,
+        authenticated_at: new Date().toISOString(),
+        authenticated_by: testUser
+      };
+      await mockChats.put(chatId.toString(), JSON.stringify(chatAuth));
+      
+      const result = await routeCommand('month', chatId, testUser, messageId, '/month', env);
+      
+      expect(result).toBeTruthy();
+      expect(result!.text).toContain("📊 This Month's Fasting Summary");
+    });
+  });
+
+  describe('handleWeekCommand', () => {
+    it('should require authentication', async () => {
+      const chatId = 12345;
+      const messageId = 100;
+      
+      const result = await handleWeekCommand(chatId, testUser, messageId, env);
+      
+      expect(result.text).toContain('Please authenticate by sending your API key first.');
+    });
+
+    it('should show no fasts message when user has no weekly history', async () => {
+      const chatId = 12345;
+      const messageId = 100;
+      
+      // Set up authentication
+      const keyHash = 'sha256:testhash';
+      const apiKeyData: ApiKeyData = {
+        name: 'Test Key',
+        expiry: new Date(Date.now() + 86400000).toISOString(),
+        created: new Date().toISOString()
+      };
+      await mockApiKeys.put(keyHash, JSON.stringify(apiKeyData));
+      
+      const chatAuth: ChatAuthData = {
+        api_key_hash: keyHash,
+        authenticated_at: new Date().toISOString(),
+        authenticated_by: testUser
+      };
+      await mockChats.put(chatId.toString(), JSON.stringify(chatAuth));
+      
+      const result = await handleWeekCommand(chatId, testUser, messageId, env);
+      
+      expect(result.text).toContain('No fasts completed this week yet');
+      expect(result.replyMarkup).toBeDefined();
+    });
+  });
+
+  describe('handleMonthCommand', () => {
+    it('should require authentication', async () => {
+      const chatId = 12345;
+      const messageId = 100;
+      
+      const result = await handleMonthCommand(chatId, testUser, messageId, env);
+      
+      expect(result.text).toContain('Please authenticate by sending your API key first.');
+    });
+
+    it('should show no fasts message when user has no monthly history', async () => {
+      const chatId = 12345;
+      const messageId = 100;
+      
+      // Set up authentication
+      const keyHash = 'sha256:testhash';
+      const apiKeyData: ApiKeyData = {
+        name: 'Test Key',
+        expiry: new Date(Date.now() + 86400000).toISOString(),
+        created: new Date().toISOString()
+      };
+      await mockApiKeys.put(keyHash, JSON.stringify(apiKeyData));
+      
+      const chatAuth: ChatAuthData = {
+        api_key_hash: keyHash,
+        authenticated_at: new Date().toISOString(),
+        authenticated_by: testUser
+      };
+      await mockChats.put(chatId.toString(), JSON.stringify(chatAuth));
+      
+      const result = await handleMonthCommand(chatId, testUser, messageId, env);
+      
+      expect(result.text).toContain('No fasts completed this month yet');
+      expect(result.replyMarkup).toBeDefined();
     });
   });
 });

--- a/test/fasting.test.ts
+++ b/test/fasting.test.ts
@@ -12,8 +12,7 @@ import {
   getLastFast,
   getRecentFasts,
   getWeeklyStatistics,
-  getMonthlyStatistics,
-  PeriodStatistics
+  getMonthlyStatistics
 } from '../src/fasting';
 import { Env, User, UserFastingData, FastEntry } from '../src/types';
 import { MockKV } from './utils/mockKv';

--- a/test/fasting.test.ts
+++ b/test/fasting.test.ts
@@ -10,7 +10,10 @@ import {
   getCurrentFastDuration,
   getFastsThisWeek,
   getLastFast,
-  getRecentFasts
+  getRecentFasts,
+  getWeeklyStatistics,
+  getMonthlyStatistics,
+  PeriodStatistics
 } from '../src/fasting';
 import { Env, User, UserFastingData, FastEntry } from '../src/types';
 import { MockKV } from './utils/mockKv';
@@ -327,6 +330,170 @@ describe('Fasting Module', () => {
       const recent = getRecentFasts(history, 5);
       expect(recent).toHaveLength(1);
       expect(recent[0]?.startedAt).toBe('2024-01-01T10:00:00Z');
+    });
+  });
+
+  describe('getWeeklyStatistics', () => {
+    it('should calculate weekly statistics correctly', () => {
+      const now = new Date();
+      const startOfWeek = new Date(now);
+      const dayOfWeek = startOfWeek.getDay();
+      const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+      startOfWeek.setDate(startOfWeek.getDate() - daysToMonday);
+      startOfWeek.setHours(0, 0, 0, 0);
+      
+      // Create fasts in current week and previous week
+      const thisWeekDay1 = new Date(startOfWeek.getTime() + 1 * 24 * 60 * 60 * 1000);
+      const thisWeekDay2 = new Date(startOfWeek.getTime() + 3 * 24 * 60 * 60 * 1000);
+      const lastWeekDay = new Date(startOfWeek.getTime() - 5 * 24 * 60 * 60 * 1000);
+      
+      const history: FastEntry[] = [
+        {
+          startedAt: lastWeekDay.toISOString(),
+          endedAt: lastWeekDay.toISOString(),
+          duration: 12 * 60 * 60 * 1000, // 12 hours
+          endedBy: testUser
+        },
+        {
+          startedAt: thisWeekDay1.toISOString(),
+          endedAt: thisWeekDay1.toISOString(),
+          duration: 16 * 60 * 60 * 1000, // 16 hours
+          endedBy: testUser
+        },
+        {
+          startedAt: thisWeekDay2.toISOString(),
+          endedAt: thisWeekDay2.toISOString(),
+          duration: 20 * 60 * 60 * 1000, // 20 hours
+          endedBy: testUser
+        }
+      ];
+      
+      const stats = getWeeklyStatistics(history, 'UTC');
+      
+      expect(stats.totalFasts).toBe(2); // Only current week fasts
+      expect(stats.totalHours).toBe(36); // 16 + 20 hours
+      expect(stats.averageDuration).toBe(18 * 60 * 60 * 1000); // 18 hours average
+      expect(stats.longestFast).toBe(20 * 60 * 60 * 1000); // 20 hours longest
+    });
+
+    it('should return zero stats for empty history', () => {
+      const stats = getWeeklyStatistics([], 'UTC');
+      
+      expect(stats.totalFasts).toBe(0);
+      expect(stats.totalHours).toBe(0);
+      expect(stats.averageDuration).toBe(0);
+      expect(stats.longestFast).toBe(0);
+    });
+
+    it('should return zero stats when no fasts this week', () => {
+      const lastMonth = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      
+      const history: FastEntry[] = [
+        {
+          startedAt: lastMonth.toISOString(),
+          endedAt: lastMonth.toISOString(),
+          duration: 16 * 60 * 60 * 1000,
+          endedBy: testUser
+        }
+      ];
+      
+      const stats = getWeeklyStatistics(history, 'UTC');
+      
+      expect(stats.totalFasts).toBe(0);
+      expect(stats.totalHours).toBe(0);
+      expect(stats.averageDuration).toBe(0);
+      expect(stats.longestFast).toBe(0);
+    });
+  });
+
+  describe('getMonthlyStatistics', () => {
+    it('should calculate monthly statistics correctly', () => {
+      const now = new Date();
+      const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+      const lastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 15);
+      
+      // Create fasts in current month and previous month
+      const thisMonthDay1 = new Date(startOfMonth.getTime() + 5 * 24 * 60 * 60 * 1000);
+      const thisMonthDay2 = new Date(startOfMonth.getTime() + 15 * 24 * 60 * 60 * 1000);
+      
+      const history: FastEntry[] = [
+        {
+          startedAt: lastMonth.toISOString(),
+          endedAt: lastMonth.toISOString(),
+          duration: 14 * 60 * 60 * 1000, // 14 hours
+          endedBy: testUser
+        },
+        {
+          startedAt: thisMonthDay1.toISOString(),
+          endedAt: thisMonthDay1.toISOString(),
+          duration: 18 * 60 * 60 * 1000, // 18 hours
+          endedBy: testUser
+        },
+        {
+          startedAt: thisMonthDay2.toISOString(),
+          endedAt: thisMonthDay2.toISOString(),
+          duration: 22 * 60 * 60 * 1000, // 22 hours
+          endedBy: testUser
+        }
+      ];
+      
+      const stats = getMonthlyStatistics(history, 'UTC');
+      
+      expect(stats.totalFasts).toBe(2); // Only current month fasts
+      expect(stats.totalHours).toBe(40); // 18 + 22 hours
+      expect(stats.averageDuration).toBe(20 * 60 * 60 * 1000); // 20 hours average
+      expect(stats.longestFast).toBe(22 * 60 * 60 * 1000); // 22 hours longest
+    });
+
+    it('should return zero stats for empty history', () => {
+      const stats = getMonthlyStatistics([], 'UTC');
+      
+      expect(stats.totalFasts).toBe(0);
+      expect(stats.totalHours).toBe(0);
+      expect(stats.averageDuration).toBe(0);
+      expect(stats.longestFast).toBe(0);
+    });
+
+    it('should return zero stats when no fasts this month', () => {
+      const threeMonthsAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+      
+      const history: FastEntry[] = [
+        {
+          startedAt: threeMonthsAgo.toISOString(),
+          endedAt: threeMonthsAgo.toISOString(),
+          duration: 16 * 60 * 60 * 1000,
+          endedBy: testUser
+        }
+      ];
+      
+      const stats = getMonthlyStatistics(history, 'UTC');
+      
+      expect(stats.totalFasts).toBe(0);
+      expect(stats.totalHours).toBe(0);
+      expect(stats.averageDuration).toBe(0);
+      expect(stats.longestFast).toBe(0);
+    });
+
+    it('should handle single fast in month', () => {
+      const now = new Date();
+      const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+      const thisMonthDay = new Date(startOfMonth.getTime() + 10 * 24 * 60 * 60 * 1000);
+      
+      const history: FastEntry[] = [
+        {
+          startedAt: thisMonthDay.toISOString(),
+          endedAt: thisMonthDay.toISOString(),
+          duration: 24 * 60 * 60 * 1000, // 24 hours
+          endedBy: testUser
+        }
+      ];
+      
+      const stats = getMonthlyStatistics(history, 'UTC');
+      
+      expect(stats.totalFasts).toBe(1);
+      expect(stats.totalHours).toBe(24);
+      expect(stats.averageDuration).toBe(24 * 60 * 60 * 1000);
+      expect(stats.longestFast).toBe(24 * 60 * 60 * 1000);
     });
   });
 });


### PR DESCRIPTION
Implements /week and /month commands for fasting statistics as requested in issue #25.

Features:
- Weekly statistics (Monday-Sunday) with timezone awareness
- Monthly statistics with timezone awareness
- Statistics include: total fasts, total hours, average duration, longest fast
- Clear, readable output formatting with emojis
- Comprehensive test coverage for edge cases
- Authentication required for both commands

🤖 Generated with [Claude Code](https://claude.ai/code)