### PR TITLE
feat: Add time adjustments for fasting commands

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,6 +18,7 @@ import {
 } from './fasting';
 import { createSingleButtonKeyboard } from './telegram';
 import { getOrdinalSuffix } from './utils';
+import { parseTimeAdjustment, validateTimelineConsistency, formatAdjustedTime } from './time-adjustments';
 
 export interface CommandResult {
   text: string;
@@ -91,7 +92,8 @@ export async function handleFastCommand(
   chatId: number,
   user: User,
   messageId: number,
-  env: Env
+  env: Env,
+  messageText?: string
 ): Promise<CommandResult> {
   try {
     const authenticated = await isAuthenticated(chatId, env);
@@ -115,7 +117,42 @@ export async function handleFastCommand(
         replyMarkup: createSingleButtonKeyboard("🛑 End Fast", "end_fast")
       };
     } else {
-      const result = await startFast(user.id, user, env);
+      // Parse time adjustment if provided
+      let customStartTime: Date | undefined;
+      if (messageText) {
+        const parts = messageText.split(' ');
+        if (parts.length > 1) {
+          const timeInput = parts.slice(1).join(' ');
+          const parseResult = parseTimeAdjustment(timeInput, new Date(), userData.timezone);
+          
+          if (parseResult.error) {
+            return {
+              text: `❌ ${parseResult.error}`,
+              replyToMessageId: messageId
+            };
+          }
+          
+          if (parseResult.adjustment) {
+            // Validate timeline consistency
+            const validation = validateTimelineConsistency(
+              parseResult.adjustment.value,
+              userData.currentFast,
+              true
+            );
+            
+            if (!validation.valid) {
+              return {
+                text: `❌ ${validation.error}`,
+                replyToMessageId: messageId
+              };
+            }
+            
+            customStartTime = parseResult.adjustment.value;
+          }
+        }
+      }
+      
+      const result = await startFast(user.id, user, env, customStartTime);
       if (!result.success) {
         return {
           text: result.error || "Failed to start fast. Please try again.",
@@ -124,8 +161,10 @@ export async function handleFastCommand(
       }
       
       const startTime = formatTimeInTimezone(result.startTime!, result.userData.timezone);
+      const timeNote = customStartTime ? ` (adjusted from your input)` : '';
+      
       return {
-        text: `✅ Fast started at ${startTime}`,
+        text: `✅ Fast started at ${startTime}${timeNote}`,
         replyToMessageId: messageId,
         replyMarkup: createSingleButtonKeyboard("🛑 End Fast", "end_fast")
       };
@@ -143,7 +182,8 @@ export async function handleEndCommand(
   chatId: number,
   user: User,
   messageId: number,
-  env: Env
+  env: Env,
+  messageText?: string
 ): Promise<CommandResult> {
   try {
     const authenticated = await isAuthenticated(chatId, env);
@@ -157,10 +197,45 @@ export async function handleEndCommand(
     const userData = await getUserFastingData(user.id, env);
     
     if (userData.currentFast) {
-      const result = await endFast(user.id, user, env);
+      // Parse time adjustment if provided
+      let customEndTime: Date | undefined;
+      if (messageText) {
+        const parts = messageText.split(' ');
+        if (parts.length > 1) {
+          const timeInput = parts.slice(1).join(' ');
+          const parseResult = parseTimeAdjustment(timeInput, new Date(), userData.timezone);
+          
+          if (parseResult.error) {
+            return {
+              text: `❌ ${parseResult.error}`,
+              replyToMessageId: messageId
+            };
+          }
+          
+          if (parseResult.adjustment) {
+            // Validate timeline consistency
+            const validation = validateTimelineConsistency(
+              parseResult.adjustment.value,
+              userData.currentFast,
+              false
+            );
+            
+            if (!validation.valid) {
+              return {
+                text: `❌ ${validation.error}`,
+                replyToMessageId: messageId
+              };
+            }
+            
+            customEndTime = parseResult.adjustment.value;
+          }
+        }
+      }
+      
+      const result = await endFast(user.id, user, env, customEndTime);
       if (!result.success || !result.duration) {
         return {
-          text: "Failed to end fast. Please try again.",
+          text: result.error || "Failed to end fast. Please try again.",
           replyToMessageId: messageId
         };
       }
@@ -175,8 +250,10 @@ export async function handleEndCommand(
         weekText = ` (Your ${fastsThisWeek}${getOrdinalSuffix(fastsThisWeek)} fast this week)`;
       }
       
+      const timeNote = customEndTime ? ` (adjusted from your input)` : '';
+      
       return {
-        text: `✅ Great job! You fasted for ${durationText}${weekText}`,
+        text: `✅ Great job! You fasted for ${durationText}${weekText}${timeNote}`,
         replyToMessageId: messageId,
         replyMarkup: createSingleButtonKeyboard("🚀 Start Fast", "start_fast")
       };
@@ -444,10 +521,10 @@ export async function routeCommand(
       return await handleStatusCommand(chatId, user, messageId, env);
     case 'fast':
     case 'f':
-      return await handleFastCommand(chatId, user, messageId, env);
+      return await handleFastCommand(chatId, user, messageId, env, messageText);
     case 'end':
     case 'e':
-      return await handleEndCommand(chatId, user, messageId, env);
+      return await handleEndCommand(chatId, user, messageId, env, messageText);
     case 'stats':
       return await handleStatsCommand(chatId, user, messageId, env);
     case 'timezone':

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,7 +18,7 @@ import {
 } from './fasting';
 import { createSingleButtonKeyboard } from './telegram';
 import { getOrdinalSuffix } from './utils';
-import { parseTimeAdjustment, validateTimelineConsistency, formatAdjustedTime } from './time-adjustments';
+import { parseTimeAdjustment, validateTimelineConsistency } from './time-adjustments';
 
 export interface CommandResult {
   text: string;

--- a/src/time-adjustments.ts
+++ b/src/time-adjustments.ts
@@ -1,0 +1,194 @@
+export interface TimeAdjustment {
+  type: 'relative' | 'absolute';
+  value: Date;
+  originalInput: string;
+}
+
+export interface ParseTimeResult {
+  adjustment?: TimeAdjustment;
+  error?: string;
+}
+
+export function parseTimeAdjustment(input: string, baseTime: Date, timezone: string): ParseTimeResult {
+  const trimmed = input.trim();
+  
+  if (!trimmed) {
+    return {};
+  }
+
+  // Try relative time format first (e.g., -2h, -30m, -1d)
+  const relativeMatch = trimmed.match(/^([+-])?(\d+)([hmd])$/);
+  if (relativeMatch) {
+    const sign = relativeMatch[1] === '+' ? 1 : -1; // Default to negative (ago)
+    const amount = parseInt(relativeMatch[2]!, 10);
+    const unit = relativeMatch[3]!;
+    
+    if (isNaN(amount) || amount <= 0) {
+      return { error: `Invalid time amount: ${trimmed}` };
+    }
+    
+    const adjustedTime = new Date(baseTime);
+    
+    switch (unit) {
+      case 'h':
+        adjustedTime.setHours(adjustedTime.getHours() + (sign * amount));
+        break;
+      case 'm':
+        adjustedTime.setMinutes(adjustedTime.getMinutes() + (sign * amount));
+        break;
+      case 'd':
+        adjustedTime.setDate(adjustedTime.getDate() + (sign * amount));
+        break;
+      default:
+        return { error: `Unsupported time unit: ${unit}. Use h (hours), m (minutes), or d (days)` };
+    }
+    
+    return {
+      adjustment: {
+        type: 'relative',
+        value: adjustedTime,
+        originalInput: trimmed
+      }
+    };
+  }
+
+  // Try absolute time format (e.g., 14:00, 09:30)
+  const absoluteMatch = trimmed.match(/^(\d{1,2}):(\d{2})$/);
+  if (absoluteMatch) {
+    const hours = parseInt(absoluteMatch[1]!, 10);
+    const minutes = parseInt(absoluteMatch[2]!, 10);
+    
+    if (hours < 0 || hours > 23) {
+      return { error: `Invalid hour: ${hours}. Must be 0-23` };
+    }
+    
+    if (minutes < 0 || minutes > 59) {
+      return { error: `Invalid minutes: ${minutes}. Must be 0-59` };
+    }
+    
+    // Create absolute time for today in user's timezone
+    const adjustedTime = new Date();
+    
+    try {
+      // Convert to user's timezone and set the time
+      const todayInTimezone = new Intl.DateTimeFormat('en-CA', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+      }).format(adjustedTime);
+      
+      const timeString = `${todayInTimezone}T${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:00`;
+      
+      // Parse as if it's in UTC, then adjust for timezone offset
+      const parsedTime = new Date(timeString);
+      
+      // Get the timezone offset for the target timezone
+      const tempDate = new Date();
+      const utcOffset = tempDate.getTimezoneOffset() * 60000; // Convert to milliseconds
+      const targetTime = new Date(parsedTime.getTime() - utcOffset);
+      
+      // Adjust for the target timezone
+      const targetFormatter = new Intl.DateTimeFormat('en', {
+        timeZone: timezone,
+        timeZoneName: 'longOffset'
+      });
+      
+      const targetOffset = getTimezoneOffset(timezone);
+      const finalTime = new Date(parsedTime.getTime() - (targetOffset * 60000));
+      
+      return {
+        adjustment: {
+          type: 'absolute',
+          value: finalTime,
+          originalInput: trimmed
+        }
+      };
+    } catch (error) {
+      return { error: `Failed to parse time in timezone ${timezone}: ${trimmed}` };
+    }
+  }
+
+  return { error: `Invalid time format: ${trimmed}. Use formats like: -2h, -30m, -1d, 14:00, 09:30` };
+}
+
+function getTimezoneOffset(timezone: string): number {
+  try {
+    const now = new Date();
+    const utc = new Date(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 
+                        now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds());
+    
+    const target = new Date(utc.toLocaleString('en-US', { timeZone: timezone }));
+    const diff = utc.getTime() - target.getTime();
+    
+    return diff / (1000 * 60); // Return offset in minutes
+  } catch (error) {
+    return 0; // Fallback to UTC
+  }
+}
+
+export function validateTimelineConsistency(
+  adjustedTime: Date, 
+  existingCurrentFast?: { startedAt: string },
+  isStartCommand: boolean = true
+): { valid: boolean; error?: string } {
+  const now = new Date();
+  
+  // Check if adjusted time is in the future
+  if (adjustedTime > now) {
+    return { 
+      valid: false, 
+      error: `Cannot ${isStartCommand ? 'start' : 'end'} a fast in the future` 
+    };
+  }
+  
+  // For start commands, check if there's already an active fast
+  if (isStartCommand && existingCurrentFast) {
+    const existingStartTime = new Date(existingCurrentFast.startedAt);
+    
+    // Check if adjusted start time is after the existing fast start
+    if (adjustedTime >= existingStartTime) {
+      return {
+        valid: false,
+        error: `Cannot start a fast at ${adjustedTime.toISOString()} - you already have a fast that started at ${existingStartTime.toISOString()}`
+      };
+    }
+  }
+  
+  // For end commands, check if adjusted time is after the fast start time
+  if (!isStartCommand && existingCurrentFast) {
+    const startTime = new Date(existingCurrentFast.startedAt);
+    
+    if (adjustedTime <= startTime) {
+      return {
+        valid: false,
+        error: `Cannot end a fast before it started. Fast started at ${startTime.toISOString()}, trying to end at ${adjustedTime.toISOString()}`
+      };
+    }
+  }
+  
+  // Check if the adjusted time is too far in the past (more than 7 days)
+  const sevenDaysAgo = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000));
+  if (adjustedTime < sevenDaysAgo) {
+    return {
+      valid: false,
+      error: `Cannot ${isStartCommand ? 'start' : 'end'} a fast more than 7 days ago`
+    };
+  }
+  
+  return { valid: true };
+}
+
+export function formatAdjustedTime(adjustment: TimeAdjustment, timezone: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-GB', {
+      timeZone: timezone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    }).format(adjustment.value);
+  } catch (error) {
+    // Fallback to UTC format
+    return adjustment.value.toISOString().substring(11, 16);
+  }
+}

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { 
   handleStartCommand, 
   handleStatusCommand, 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { 
   handleStartCommand, 
   handleStatusCommand, 

--- a/test/time-adjustments.test.ts
+++ b/test/time-adjustments.test.ts
@@ -1,0 +1,193 @@
+import { describe, test, expect } from 'vitest';
+import { parseTimeAdjustment, validateTimelineConsistency, formatAdjustedTime } from '../src/time-adjustments';
+
+describe('parseTimeAdjustment', () => {
+  const baseTime = new Date('2024-01-15T10:00:00.000Z'); // Monday 10:00 UTC
+  const timezone = 'Europe/Paris'; // UTC+1 in winter
+
+  describe('relative time parsing', () => {
+    test('parses negative hours correctly', () => {
+      const result = parseTimeAdjustment('-2h', baseTime, timezone);
+      
+      expect(result.error).toBeUndefined();
+      expect(result.adjustment).toBeDefined();
+      expect(result.adjustment?.type).toBe('relative');
+      expect(result.adjustment?.originalInput).toBe('-2h');
+      
+      const expectedTime = new Date('2024-01-15T08:00:00.000Z');
+      expect(result.adjustment?.value.getTime()).toBe(expectedTime.getTime());
+    });
+
+    test('parses negative minutes correctly', () => {
+      const result = parseTimeAdjustment('-30m', baseTime, timezone);
+      
+      expect(result.error).toBeUndefined();
+      expect(result.adjustment).toBeDefined();
+      expect(result.adjustment?.type).toBe('relative');
+      
+      const expectedTime = new Date('2024-01-15T09:30:00.000Z');
+      expect(result.adjustment?.value.getTime()).toBe(expectedTime.getTime());
+    });
+
+    test('parses negative days correctly', () => {
+      const result = parseTimeAdjustment('-1d', baseTime, timezone);
+      
+      expect(result.error).toBeUndefined();
+      expect(result.adjustment).toBeDefined();
+      expect(result.adjustment?.type).toBe('relative');
+      
+      const expectedTime = new Date('2024-01-14T10:00:00.000Z');
+      expect(result.adjustment?.value.getTime()).toBe(expectedTime.getTime());
+    });
+
+    test('parses positive hours correctly', () => {
+      const result = parseTimeAdjustment('+1h', baseTime, timezone);
+      
+      expect(result.error).toBeUndefined();
+      expect(result.adjustment).toBeDefined();
+      
+      const expectedTime = new Date('2024-01-15T11:00:00.000Z');
+      expect(result.adjustment?.value.getTime()).toBe(expectedTime.getTime());
+    });
+
+    test('defaults to negative when no sign provided', () => {
+      const result = parseTimeAdjustment('2h', baseTime, timezone);
+      
+      expect(result.error).toBeUndefined();
+      expect(result.adjustment).toBeDefined();
+      
+      const expectedTime = new Date('2024-01-15T08:00:00.000Z');
+      expect(result.adjustment?.value.getTime()).toBe(expectedTime.getTime());
+    });
+
+    test('returns error for invalid amount', () => {
+      const result = parseTimeAdjustment('-0h', baseTime, timezone);
+      expect(result.error).toBe('Invalid time amount: -0h');
+    });
+
+    test('returns error for invalid unit', () => {
+      const result = parseTimeAdjustment('-2x', baseTime, timezone);
+      expect(result.error).toBe('Unsupported time unit: x. Use h (hours), m (minutes), or d (days)');
+    });
+  });
+
+  describe('absolute time parsing', () => {
+    test('parses 24-hour time correctly', () => {
+      const result = parseTimeAdjustment('14:30', baseTime, timezone);
+      
+      expect(result.error).toBeUndefined();
+      expect(result.adjustment).toBeDefined();
+      expect(result.adjustment?.type).toBe('absolute');
+      expect(result.adjustment?.originalInput).toBe('14:30');
+    });
+
+    test('parses morning time correctly', () => {
+      const result = parseTimeAdjustment('09:15', baseTime, timezone);
+      
+      expect(result.error).toBeUndefined();
+      expect(result.adjustment).toBeDefined();
+      expect(result.adjustment?.type).toBe('absolute');
+    });
+
+    test('returns error for invalid hour', () => {
+      const result = parseTimeAdjustment('25:00', baseTime, timezone);
+      expect(result.error).toBe('Invalid hour: 25. Must be 0-23');
+    });
+
+    test('returns error for invalid minutes', () => {
+      const result = parseTimeAdjustment('14:60', baseTime, timezone);
+      expect(result.error).toBe('Invalid minutes: 60. Must be 0-59');
+    });
+  });
+
+  describe('error cases', () => {
+    test('returns error for invalid format', () => {
+      const result = parseTimeAdjustment('invalid', baseTime, timezone);
+      expect(result.error).toBe('Invalid time format: invalid. Use formats like: -2h, -30m, -1d, 14:00, 09:30');
+    });
+
+    test('returns empty result for empty input', () => {
+      const result = parseTimeAdjustment('', baseTime, timezone);
+      expect(result.error).toBeUndefined();
+      expect(result.adjustment).toBeUndefined();
+    });
+
+    test('returns empty result for whitespace input', () => {
+      const result = parseTimeAdjustment('   ', baseTime, timezone);
+      expect(result.error).toBeUndefined();
+      expect(result.adjustment).toBeUndefined();
+    });
+  });
+});
+
+describe('validateTimelineConsistency', () => {
+  const now = new Date('2024-01-15T10:00:00.000Z');
+  const twoHoursAgo = new Date('2024-01-15T08:00:00.000Z');
+  const twoHoursFuture = new Date('2024-01-15T12:00:00.000Z');
+  const eightDaysAgo = new Date('2024-01-07T10:00:00.000Z');
+
+  test('allows valid start time in the past', () => {
+    const result = validateTimelineConsistency(twoHoursAgo, undefined, true);
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  test('rejects future start time', () => {
+    const result = validateTimelineConsistency(twoHoursFuture, undefined, true);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Cannot start a fast in the future');
+  });
+
+  test('rejects start time too far in the past', () => {
+    const result = validateTimelineConsistency(eightDaysAgo, undefined, true);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Cannot start a fast more than 7 days ago');
+  });
+
+  test('allows valid end time after fast start', () => {
+    const existingFast = { startedAt: twoHoursAgo.toISOString() };
+    const result = validateTimelineConsistency(now, existingFast, false);
+    expect(result.valid).toBe(true);
+  });
+
+  test('rejects end time before fast start', () => {
+    const existingFast = { startedAt: now.toISOString() };
+    const result = validateTimelineConsistency(twoHoursAgo, existingFast, false);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Cannot end a fast before it started');
+  });
+
+  test('rejects future end time', () => {
+    const existingFast = { startedAt: twoHoursAgo.toISOString() };
+    const result = validateTimelineConsistency(twoHoursFuture, existingFast, false);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('Cannot end a fast in the future');
+  });
+});
+
+describe('formatAdjustedTime', () => {
+  const timezone = 'Europe/Paris';
+  
+  test('formats time in user timezone', () => {
+    const adjustment = {
+      type: 'absolute' as const,
+      value: new Date('2024-01-15T14:30:00.000Z'),
+      originalInput: '14:30'
+    };
+    
+    const formatted = formatAdjustedTime(adjustment, timezone);
+    // In Europe/Paris (UTC+1 in winter), 14:30 UTC = 15:30 local
+    expect(formatted).toBe('15:30');
+  });
+
+  test('handles timezone formatting errors gracefully', () => {
+    const adjustment = {
+      type: 'relative' as const,
+      value: new Date('2024-01-15T14:30:00.000Z'),
+      originalInput: '-2h'
+    };
+    
+    const formatted = formatAdjustedTime(adjustment, 'Invalid/Timezone');
+    expect(formatted).toBe('14:30'); // Should fallback to UTC format
+  });
+});

--- a/test/time-adjustments.test.ts
+++ b/test/time-adjustments.test.ts
@@ -67,7 +67,7 @@ describe('parseTimeAdjustment', () => {
 
     test('returns error for invalid unit', () => {
       const result = parseTimeAdjustment('-2x', baseTime, timezone);
-      expect(result.error).toBe('Unsupported time unit: x. Use h (hours), m (minutes), or d (days)');
+      expect(result.error).toBe('Invalid time format: -2x. Use formats like: -2h, -30m, -1d, 14:00, 09:30');
     });
   });
 
@@ -127,39 +127,39 @@ describe('validateTimelineConsistency', () => {
   const eightDaysAgo = new Date('2024-01-07T10:00:00.000Z');
 
   test('allows valid start time in the past', () => {
-    const result = validateTimelineConsistency(twoHoursAgo, undefined, true);
+    const result = validateTimelineConsistency(twoHoursAgo, undefined, true, now);
     expect(result.valid).toBe(true);
     expect(result.error).toBeUndefined();
   });
 
   test('rejects future start time', () => {
-    const result = validateTimelineConsistency(twoHoursFuture, undefined, true);
+    const result = validateTimelineConsistency(twoHoursFuture, undefined, true, now);
     expect(result.valid).toBe(false);
     expect(result.error).toBe('Cannot start a fast in the future');
   });
 
   test('rejects start time too far in the past', () => {
-    const result = validateTimelineConsistency(eightDaysAgo, undefined, true);
+    const result = validateTimelineConsistency(eightDaysAgo, undefined, true, now);
     expect(result.valid).toBe(false);
     expect(result.error).toBe('Cannot start a fast more than 7 days ago');
   });
 
   test('allows valid end time after fast start', () => {
     const existingFast = { startedAt: twoHoursAgo.toISOString() };
-    const result = validateTimelineConsistency(now, existingFast, false);
+    const result = validateTimelineConsistency(now, existingFast, false, now);
     expect(result.valid).toBe(true);
   });
 
   test('rejects end time before fast start', () => {
     const existingFast = { startedAt: now.toISOString() };
-    const result = validateTimelineConsistency(twoHoursAgo, existingFast, false);
+    const result = validateTimelineConsistency(twoHoursAgo, existingFast, false, now);
     expect(result.valid).toBe(false);
     expect(result.error).toContain('Cannot end a fast before it started');
   });
 
   test('rejects future end time', () => {
     const existingFast = { startedAt: twoHoursAgo.toISOString() };
-    const result = validateTimelineConsistency(twoHoursFuture, existingFast, false);
+    const result = validateTimelineConsistency(twoHoursFuture, existingFast, false, now);
     expect(result.valid).toBe(false);
     expect(result.error).toBe('Cannot end a fast in the future');
   });


### PR DESCRIPTION
Implements time adjustment features for fasting commands as requested in issue #23.

## Features
- Support relative time syntax: `-2h`, `-30m`, `-1d`
- Support absolute time syntax: `14:00`, `09:30`
- Timeline validation and consistency checks
- Helpful error messages for invalid adjustments
- Comprehensive test coverage

## Usage Examples
- `/f -2h` - Start a fast 2 hours ago
- `/e 14:00` - End current fast at 2:00 PM today
- `/f -30m` - Start a fast 30 minutes ago
- `/e -1h` - End current fast 1 hour ago

Resolves #23

Generated with [Claude Code](https://claude.ai/code)