### PR TITLE
test: add error handling tests for natural language date formats

### DIFF
--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -276,6 +276,33 @@ describe('Commands Module', () => {
       expect(result.text).toContain('❌');
       expect(result.text).toContain('Invalid time format');
     });
+
+    it('should return error for natural language date format "yesterday 14:00"', async () => {
+      const chatId = 12345;
+      const messageId = 100;
+      
+      // Set up authentication
+      const keyHash = 'sha256:testhash';
+      const apiKeyData: ApiKeyData = {
+        name: 'Test Key',
+        expiry: new Date(Date.now() + 86400000).toISOString(),
+        created: new Date().toISOString()
+      };
+      await mockApiKeys.put(keyHash, JSON.stringify(apiKeyData));
+      
+      const chatAuth: ChatAuthData = {
+        api_key_hash: keyHash,
+        authenticated_at: new Date().toISOString(),
+        authenticated_by: testUser
+      };
+      await mockChats.put(chatId.toString(), JSON.stringify(chatAuth));
+      
+      const result = await handleFastCommand(chatId, testUser, messageId, env, '/f yesterday 14:00');
+      
+      expect(result.text).toContain('❌');
+      expect(result.text).toContain('Invalid time format: yesterday 14:00');
+      expect(result.text).toContain('Use formats like: -2h, -30m, -1d, 14:00, 09:30');
+    });
   });
 
   describe('handleEndCommand', () => {

--- a/test/time-adjustments.test.ts
+++ b/test/time-adjustments.test.ts
@@ -117,6 +117,21 @@ describe('parseTimeAdjustment', () => {
       expect(result.error).toBeUndefined();
       expect(result.adjustment).toBeUndefined();
     });
+
+    test('returns error for natural language date formats like "yesterday 14:00"', () => {
+      const result = parseTimeAdjustment('yesterday 14:00', baseTime, timezone);
+      expect(result.error).toBe('Invalid time format: yesterday 14:00. Use formats like: -2h, -30m, -1d, 14:00, 09:30');
+    });
+
+    test('returns error for "today 14:00" format', () => {
+      const result = parseTimeAdjustment('today 14:00', baseTime, timezone);
+      expect(result.error).toBe('Invalid time format: today 14:00. Use formats like: -2h, -30m, -1d, 14:00, 09:30');
+    });
+
+    test('returns error for "tomorrow 14:00" format', () => {
+      const result = parseTimeAdjustment('tomorrow 14:00', baseTime, timezone);
+      expect(result.error).toBe('Invalid time format: tomorrow 14:00. Use formats like: -2h, -30m, -1d, 14:00, 09:30');
+    });
   });
 });
 

--- a/test/time-adjustments.test.ts
+++ b/test/time-adjustments.test.ts
@@ -131,6 +131,13 @@ describe('parseTimeAdjustment', () => {
     test('returns error for "tomorrow 14:00" format', () => {
       const result = parseTimeAdjustment('tomorrow 14:00', baseTime, timezone);
       expect(result.error).toBe('Invalid time format: tomorrow 14:00. Use formats like: -2h, -30m, -1d, 14:00, 09:30');
+    test.each([
+      'yesterday 14:00',
+      'today 14:00',
+      'tomorrow 14:00',
+    ])('returns error for natural language date format "%s"', (input) => {
+      const result = parseTimeAdjustment(input, baseTime, timezone);
+      expect(result.error).toBe(`Invalid time format: ${input}. Use formats like: -2h, -30m, -1d, 14:00, 09:30`);
     });
   });
 });

--- a/test/time-adjustments.test.ts
+++ b/test/time-adjustments.test.ts
@@ -118,19 +118,6 @@ describe('parseTimeAdjustment', () => {
       expect(result.adjustment).toBeUndefined();
     });
 
-    test('returns error for natural language date formats like "yesterday 14:00"', () => {
-      const result = parseTimeAdjustment('yesterday 14:00', baseTime, timezone);
-      expect(result.error).toBe('Invalid time format: yesterday 14:00. Use formats like: -2h, -30m, -1d, 14:00, 09:30');
-    });
-
-    test('returns error for "today 14:00" format', () => {
-      const result = parseTimeAdjustment('today 14:00', baseTime, timezone);
-      expect(result.error).toBe('Invalid time format: today 14:00. Use formats like: -2h, -30m, -1d, 14:00, 09:30');
-    });
-
-    test('returns error for "tomorrow 14:00" format', () => {
-      const result = parseTimeAdjustment('tomorrow 14:00', baseTime, timezone);
-      expect(result.error).toBe('Invalid time format: tomorrow 14:00. Use formats like: -2h, -30m, -1d, 14:00, 09:30');
     test.each([
       'yesterday 14:00',
       'today 14:00',


### PR DESCRIPTION
- Added test cases to validate error messages for unsupported formats like "yesterday 14:00", "today 14:00", and "tomorrow 14:00".